### PR TITLE
WIP : merge notifications

### DIFF
--- a/service/src/main/java/org/exoplatform/push/service/fcm/FCMMessagePublisher.java
+++ b/service/src/main/java/org/exoplatform/push/service/fcm/FCMMessagePublisher.java
@@ -119,9 +119,14 @@ public class FCMMessagePublisher implements MessagePublisher {
     StringBuilder requestBody = new StringBuilder()
             .append("{")
             .append("  \"validate_only\": false,")
-            .append("  \"message\": {")
-            .append("    \"notification\": {")
-            .append("      \"title\": \"").append(message.getTitle()).append("\",")
+            .append("  \"message\": {");
+    // TODO sending notifications differently between Android and iOS, waiting for message handling implementation in iOS
+    if(StringUtils.isNotBlank(message.getDeviceType()) && message.getDeviceType().equals("android")) {
+      requestBody.append("    \"data\": {");
+    } else {
+      requestBody.append("    \"notification\": {");
+    }
+    requestBody.append("      \"title\": \"").append(message.getTitle()).append("\",")
             .append("      \"body\": \"").append(message.getBody()).append("\"")
             .append("    },");
     if(fcmMessageExpirationTime != null && StringUtils.isNotBlank(message.getDeviceType())) {

--- a/service/src/test/java/org/exoplatform/push/service/fcm/FCMMessagePublisherTest.java
+++ b/service/src/test/java/org/exoplatform/push/service/fcm/FCMMessagePublisherTest.java
@@ -18,6 +18,7 @@ import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
 import java.security.PrivateKey;
+import java.util.List;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -97,21 +98,38 @@ public class FCMMessagePublisherTest {
 
     // When
     messagePublisher.send(new Message("john", "token1", "android", "My Notification Title", "My Notification Body"));
+    messagePublisher.send(new Message("mary", "token2", "ios", "My Notification Title", "My Notification Body"));
 
     // Then
-    verify(httpClient, times(1)).execute(reqArgs.capture());
-    HttpPost httpUriRequest = reqArgs.getValue();
-    assertNotNull(httpUriRequest);
+    verify(httpClient, times(2)).execute(reqArgs.capture());
+
+    List<HttpPost> httpUriRequests = reqArgs.getAllValues();
+    assertNotNull(httpUriRequests);
+
+    HttpPost httpUriRequest = httpUriRequests.get(0);
     String body = IOUtils.toString(httpUriRequest.getEntity().getContent(), "UTF-8");
     JSONObject jsonMessage = new JSONObject(body);
     assertEquals(false, jsonMessage.getBoolean("validate_only"));
     JSONObject message = jsonMessage.getJSONObject("message");
-    JSONObject notification = message.getJSONObject("notification");
+    JSONObject notification = message.getJSONObject("data");
     assertEquals("My Notification Title", notification.getString("title"));
     assertEquals("My Notification Body", notification.getString("body"));
     assertEquals("token1", message.getString("token"));
     assertFalse(message.has("android"));
-    assertFalse(message.has("ios"));
+    assertFalse(message.has("apns"));
+
+    httpUriRequest = httpUriRequests.get(1);
+    assertNotNull(httpUriRequest);
+    body = IOUtils.toString(httpUriRequest.getEntity().getContent(), "UTF-8");
+    jsonMessage = new JSONObject(body);
+    assertEquals(false, jsonMessage.getBoolean("validate_only"));
+    message = jsonMessage.getJSONObject("message");
+    notification = message.getJSONObject("notification");
+    assertEquals("My Notification Title", notification.getString("title"));
+    assertEquals("My Notification Body", notification.getString("body"));
+    assertEquals("token2", message.getString("token"));
+    assertFalse(message.has("android"));
+    assertFalse(message.has("apns"));
   }
 
   @Test
@@ -183,20 +201,37 @@ public class FCMMessagePublisherTest {
 
     // When
     messagePublisher.send(new Message("john", "token1", "android", "My Notification Title", "My Notification Body"));
+    messagePublisher.send(new Message("mary", "token2", "ios", "My Notification Title", "My Notification Body"));
 
     // Then
-    verify(httpClient, times(1)).execute(reqArgs.capture());
-    HttpPost httpUriRequest = reqArgs.getValue();
-    assertNotNull(httpUriRequest);
+    verify(httpClient, times(2)).execute(reqArgs.capture());
+
+    List<HttpPost> httpUriRequests = reqArgs.getAllValues();
+    assertNotNull(httpUriRequests);
+    HttpPost httpUriRequest = httpUriRequests.get(0);
     String body = IOUtils.toString(httpUriRequest.getEntity().getContent(), "UTF-8");
     JSONObject jsonMessage = new JSONObject(body);
     assertEquals(false, jsonMessage.getBoolean("validate_only"));
     JSONObject message = jsonMessage.getJSONObject("message");
-    JSONObject notification = message.getJSONObject("notification");
+    JSONObject notification = message.getJSONObject("data");
     assertEquals("My Notification Title", notification.getString("title"));
     assertEquals("My Notification Body", notification.getString("body"));
     assertEquals("token1", message.getString("token"));
     JSONObject android = message.getJSONObject("android");
+    assertEquals("60s", android.getString("ttl"));
+    assertFalse(message.has("ios"));
+
+    httpUriRequest = httpUriRequests.get(1);
+    assertNotNull(httpUriRequest);
+    body = IOUtils.toString(httpUriRequest.getEntity().getContent(), "UTF-8");
+    jsonMessage = new JSONObject(body);
+    assertEquals(false, jsonMessage.getBoolean("validate_only"));
+    message = jsonMessage.getJSONObject("message");
+    notification = message.getJSONObject("notification");
+    assertEquals("My Notification Title", notification.getString("title"));
+    assertEquals("My Notification Body", notification.getString("body"));
+    assertEquals("token2", message.getString("token"));
+    JSONObject ios = message.getJSONObject("apns");
     assertEquals("60s", android.getString("ttl"));
     assertFalse(message.has("ios"));
   }


### PR DESCRIPTION
This PR implements the merge of push notifications when multiple notifications are received.

The way notifications are sent to Firebase is changed (uses "data" instead of "notification"), so that notifications are not displayed automatically by Android and can be processed before display.
Only the Android notifications are changed for the moment because the change are only done on the Android version ofthe mobile application. Once done on iOS application, the notifications will be sent the same way for all devices ("data").