### PR TITLE
SWF-4705 : depends on 5.1.x-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <artifactId>addons-parent-pom</artifactId>
         <groupId>org.exoplatform.addons</groupId>
-        <version>7</version>
+        <version>9</version>
     </parent>
     <groupId>org.exoplatform.addons.push-notifications</groupId>
     <artifactId>exo-push-notifications</artifactId>
@@ -51,7 +51,7 @@
         <!-- **************************************** -->
         <!-- Dependencies versions -->
         <!-- **************************************** -->
-        <org.exoplatform.platform.version>5.0.0</org.exoplatform.platform.version>
+        <org.exoplatform.platform.version>5.1.x-SNAPSHOT</org.exoplatform.platform.version>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
This fix updates the pom to depend on version 5.1.x-SNAPSHOT of PLF and
version 9 of addons parent pom.