### PR TITLE
PLF-8460 : Problem in eXo push notification addon : cookie array is null

### DIFF
--- a/service/src/main/java/org/exoplatform/push/filter/AuthenticationHeaderFilter.java
+++ b/service/src/main/java/org/exoplatform/push/filter/AuthenticationHeaderFilter.java
@@ -55,9 +55,11 @@ public class AuthenticationHeaderFilter implements Filter {
   }
 
   protected String getCookieValue(Cookie[] cookies, Object key) {
-    for (int i = 0; i < cookies.length; i++) {
-      if (key.equals(cookies[i].getName())) {
-        return cookies[i].getValue();
+    if (cookies!=null) {
+      for (int i = 0; i < cookies.length; i++) {
+        if (key.equals(cookies[i].getName())) {
+          return cookies[i].getValue();
+        }
       }
     }
     return null;

--- a/service/src/test/java/org/exoplatform/push/filter/AuthenticationHeaderFilterTest.java
+++ b/service/src/test/java/org/exoplatform/push/filter/AuthenticationHeaderFilterTest.java
@@ -117,4 +117,18 @@ public class AuthenticationHeaderFilterTest {
     assertTrue(authenticationHeaderTokens.contains("JSESSIONID=valueJSESSIONID"));
     assertTrue(authenticationHeaderTokens.contains("JSESSIONIDSSO=valueJSESSIONIDSSO"));
   }
+
+  @Test
+  public void shouldNotThrowsNPE() {
+
+    AuthenticationHeaderFilter filter = new AuthenticationHeaderFilter();
+    try {
+      filter.getCookieValue(null,"test");
+      assertTrue(Boolean.TRUE);
+    } catch(NullPointerException ex) {
+      fail("NullPointereException in getCookieValue");
+    }
+
+
+  }
 }


### PR DESCRIPTION
This change is needed because an NPE can be thrown in getCookieValue if cookie array is null
This change add a test before using the array to check if it is null or not